### PR TITLE
Only validate that `data` key is present

### DIFF
--- a/lib/jsonapi/parser/resource.rb
+++ b/lib/jsonapi/parser/resource.rb
@@ -11,7 +11,7 @@ module JSONAPI
         Document.ensure!(document.is_a?(Hash),
                          'A JSON object MUST be at the root of every JSONAPI ' \
                          'request and response containing data.')
-        Document.ensure!(document.keys == ['data'].freeze &&
+        Document.ensure!(document.keys.include?('data') &&
                          document['data'].is_a?(Hash),
                          'The request MUST include a single resource object ' \
                          'as primary data.')

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -92,4 +92,61 @@ describe JSONAPI::Parser, '.parse_response!' do
       'A resource identifier object MUST contain ["id", "type"] members.'
     )
   end
+
+  context 'with valid included relationship' do
+    before(:each) do
+      @payload = {
+        'data' => [
+          {
+            'type' => 'articles',
+            'id' => '1',
+            'relationships' => {
+              'author' => {
+                'data' => { 'type' => 'people', 'id' => '9' }
+              }
+            }
+          }
+        ],
+        'included' => [
+          {
+            'type' => 'people',
+            'id' => '9'
+          }
+        ]
+      }
+    end
+
+    it 'succeeds with valid includes' do
+      expect { JSONAPI.parse_response!(@payload) }.not_to raise_error
+    end
+  end
+
+  context 'with invalid included relationship' do
+    before(:each) do
+      @payload = {
+        'data' => [
+          {
+            'type' => 'articles',
+            'id' => '1',
+            'relationships' => {
+              'author' => {
+                'data' => { 'type' => 'people', 'id' => '9' }
+              }
+            }
+          }
+        ],
+        'included' => {
+          'type' => 'people',
+          'id' => '9'
+        }
+      }
+    end
+
+    it 'fails when included relationships are not an array' do
+      expect { JSONAPI.parse_response!(@payload) }.to raise_error(
+        JSONAPI::Parser::InvalidDocument,
+        'Top level included member must be an array.'
+      )
+    end
+  end
 end


### PR DESCRIPTION
If a JSON-API document contains `included` relationships, the parser throws an error. This PR addresses it by only checking for the presence of the `data` top level key.